### PR TITLE
Allow optional header giving a proxy path.

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     ],
     "name": "vfs-http-adapter",
     "description": "A http middleware to wrap vfs instances and expose them via a RESTful interface",
-    "version": "0.2.3",
+    "version": "0.2.4",
     "repository": {
         "type": "git",
         "url": "git://github.com/c9/vfs-http-adapter.git"

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     ],
     "name": "vfs-http-adapter",
     "description": "A http middleware to wrap vfs instances and expose them via a RESTful interface",
-    "version": "0.2.4",
+    "version": "0.2.5",
     "repository": {
         "type": "git",
         "url": "git://github.com/c9/vfs-http-adapter.git"

--- a/restful.js
+++ b/restful.js
@@ -189,6 +189,9 @@ module.exports = function setup(mount, vfs, mountOptions) {
         vfs.mkfile(path, { stream: stream }, function (err, meta) {
           if (err) return abort(err);
           res.end();
+          fs.unlink(req.files['files'][0].path, function(err){
+            console.log("Cannot delete ", req.files['files'][0].path);
+          });
         });
       }
     } // end PUT request

--- a/restful.js
+++ b/restful.js
@@ -189,7 +189,7 @@ module.exports = function setup(mount, vfs, mountOptions) {
         vfs.mkfile(path, { stream: stream }, function (err, meta) {
           if (err) return abort(err);
           res.end();
-          fs.unlink(req.files['files'][0].path, function(err){
+          fs.unlink(req.files['files'][0].path, function(err) {
             console.log("Cannot delete ", req.files['files'][0].path);
           });
         });

--- a/restful.js
+++ b/restful.js
@@ -189,9 +189,9 @@ module.exports = function setup(mount, vfs, mountOptions) {
         vfs.mkfile(path, { stream: stream }, function (err, meta) {
           if (err) return abort(err);
           res.end();
-          fs.unlink(req.files['files'][0].path, function(err) {
-            console.log("Cannot delete ", req.files['files'][0].path);
-          });
+          // fs.unlink(req.files['files'][0].path, function(err) {
+          //   console.log("Cannot delete ", req.files['files'][0].path);
+          // });
         });
       }
     } // end PUT request

--- a/restful.js
+++ b/restful.js
@@ -184,7 +184,8 @@ module.exports = function setup(mount, vfs, mountOptions) {
         });
       } else {
         // FIXME: This causes a double write but with auth, the req stream stops being readable.
-        var stream = fs.createReadStream(req.files['file-1'].path);
+        console.log(req.files);
+        var stream = fs.createReadStream(req.files['files'][0].path);
         vfs.mkfile(path, { stream: stream }, function (err, meta) {
           if (err) return abort(err);
           res.end();

--- a/restful.js
+++ b/restful.js
@@ -194,13 +194,15 @@ module.exports = function setup(mount, vfs, mountOptions) {
     } // end PUT request
 
     else if (req.method === "DELETE") {
-      var command;
+      var command, options;
       if (path[path.length - 1] === "/") {
         command = vfs.rmdir;
+        options = {recursive: true}
       } else {
         command = vfs.rmfile;
+        options = {};
       }
-      command(path, {}, function (err, meta) {
+      command(path, options, function (err, meta) {
         if (err) return abort(err);
         res.end();
       });


### PR DESCRIPTION
Using vfs-http-adapter through a proxy is a little tricky.  This patch checks an optional header header, `vfs-remote-path`, and returns correct href fields.  This is also useful if the external folder structure does not match the disk folder structure.
